### PR TITLE
Fix EPSILON

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var glVec3 = {
 }
 
 var Y_UP = [0, 1, 0]
-var EPSILON = Number.EPSILON
+var EPSILON = Math.pow(2, -23)
 var tmpVec3 = [0, 0, 0]
 
 module.exports = createOrbitControls


### PR DESCRIPTION
The title of #10 should have read "EPSILON way too small".

Suggesting `Number.EPSILON` was a mistake as it relates to doubles and is far too small.

e335c74b72609f2cc948ce08a067dda0700fdef1 broke pitching a `perspective-camera` all the way "up" or "down" using an `orbit-controls`.

This is due to routines like gl-mat4/invert failing to behave when backed by `Float32Array`s which I demonstrate in #5

See https://en.wikipedia.org/wiki/Machine_epsilon for formulaic explanations.

For the record: `gl-matrix` uses `0.000001` which you'll agree is more than close enough.

I apologise for any confusion as well as my mistaken suggestion.

This change should also alleviate many instances of #5 ^w^
