### PR TITLE
Fix disable not disabling mousedown

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -77,7 +77,7 @@ function inputEvents (opt) {
       }
     }
     if (rotateFn) {
-      parent.removeEventListener('mousedown', onInputDown, false)
+      element.removeEventListener('mousedown', onInputDown, false)
       parent.removeEventListener('mousemove', onInputMove, false)
       parent.removeEventListener('mouseup', onInputUp, false)
     }


### PR DESCRIPTION
Hey @mattdesl are you still maintaining this repo? I found a bug


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [x] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description
When running `disable()` the orbitControls would not disable on the `mousedown` event.

## Solution Description
Call `removeEventListener` on the correct element the listener was attached to.

